### PR TITLE
fix: latest core changes for rb

### DIFF
--- a/lib/ruby/turbine_rb/lib/turbine_rb/client.rb
+++ b/lib/ruby/turbine_rb/lib/turbine_rb/client.rb
@@ -19,7 +19,7 @@ module TurbineRb
           unwrapped_records = records.unwrap
         end
 
-        pr = TurbineCore::Process.new(
+        pr = TurbineCore::ProcessCollectionRequest::Process.new(
           name: process.class.name
         )
 
@@ -48,7 +48,7 @@ module TurbineRb
           if records.instance_of?(Collection) # it has been processed by a function, so unwrap back to gRPC collection
             records = records.unwrap
           end
-          req = TurbineCore::WriteCollectionRequest.new(resource: @pb_resource, collection: records,
+          req = TurbineCore::WriteCollectionRequest.new(resource: @pb_resource, sourceCollection: records,
                                                     targetCollection: collection)
           req.configs = configs if configs
           @app.core_server.write_collection_to_resource(req)


### PR DESCRIPTION
**Before**

```
        pr = TurbineCore::Process.new(
                        ^^^^^^^^^
	from /Users/rb/code/meroxa/turbine-examples/ruby/simple/app.rb:18:in `call'
	from /Users/rb/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/turbine_rb-0.1.0/lib/turbine_rb.rb:52:in `run'
	from -e:1:in `<main>'
exit status 1
Error: exit status 1
```

```
Unknown field name 'collection' in initialization map entry. (ArgumentError)
	from /Users/rb/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/turbine_rb-0.1.0/lib/turbine_rb/client.rb:60:in `new'
	from /Users/rb/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/turbine_rb-0.1.0/lib/turbine_rb/client.rb:60:in `write'
	from /Users/rb/code/meroxa/turbine-examples/ruby/simple/app.rb:19:in `call'
	from /Users/rb/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/turbine_rb-0.1.0/lib/turbine_rb.rb:52:in `run'
	from -e:1:in `<main>'
exit status 1
Error: exit status 1
```

**After**

It works.