### PR TITLE
ci: add ruby specs to GitHub action

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -15,5 +15,13 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version: 1.19
-      - name: Run tests
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.1.2'
+          bundler-cache: true
+      - name: Run go tests
         run: make test
+      - name: Run ruby tests
+        run: |
+          make setup_turbine_rb
+          make test_turbine_rb

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,13 @@ gomod:
 test:
 	go test ./... -coverprofile=c.out -covermode=atomic -v
 
+.PHONY: setup_turbine_rb
+setup_turbine_rb:
+	bundle install --gemfile=./lib/ruby/turbine_rb/Gemfile
+
+.PHONY: test_turbine_rb
+test_turbine_rb:
+	rake -C ./lib/ruby/turbine_rb spec
 
 .PHONY: proto
 proto: turbine_proto process_ruby_proto turbine_ruby_proto


### PR DESCRIPTION
Adds ruby tests after go tests in the github runner.

## How to verify
Check out the action and see the turbine rb dependency install + successful test run
<img width="549" alt="Screen Shot 2022-11-18 at 2 48 29 PM" src="https://user-images.githubusercontent.com/4818826/202789912-ed3a58ef-e362-4ef4-ac9e-db6548401d29.png">

