### PR TITLE
fix(turbine_rb): correct server references

### DIFF
--- a/lib/ruby/turbine_rb/lib/turbine_rb.rb
+++ b/lib/ruby/turbine_rb/lib/turbine_rb.rb
@@ -36,13 +36,13 @@ module TurbineRb
     end
 
     def run
-      server = init_core_server()
+      core_server = init_core_server()
       app = TurbineRb::Client::App.new(core_server)
       TurbineRb.app.call(app)
     end
 
     def record
-      server = init_core_server()
+      core_server = init_core_server()
       app = TurbineRb::Client::App.new(core_server, is_recording: true)
       TurbineRb.app.call(app)
     end


### PR DESCRIPTION
Fixes references for the server after refactoring the init function