### PR TITLE
feat: Add Record wrappers for working w records

### DIFF
--- a/lib/ruby/turbine_rb/lib/templates/app/app.rb
+++ b/lib/ruby/turbine_rb/lib/templates/app/app.rb
@@ -15,7 +15,7 @@ class MyApp
     records = database.records(collection: 'events')
 
     # This register the secret to be available in the turbine application
-    app.register_secrets("MY_ENV_TEST") 
+    app.register_secrets("MY_ENV_TEST")
 
     # you can also register several secrets at once
     # app.register_secrets(["MY_ENV_TEST", "MY_OTHER_ENV_TEST"])
@@ -35,7 +35,17 @@ end
 class Passthrough < TurbineRb::Process # might be useful to signal that this is a special Turbine call
   def call(records:)
     puts "got records: #{records}"
-    # records.map { |r| r.value = 'hi there' }
+    # to get the value of unformatted records, use record .value getter method
+    # records.map { |r| puts r.value }
+    #
+    # to transform unformatted records, use record .value setter method
+    # records.map { |r| r.value = "newdata" }
+    #
+    # to get the value of json formatted records, use record .get method
+    # records.map { |r| puts r.get("message") }
+    #
+    # to transform json formatted records, use record .set methods
+    # records.map { |r| r.set('message', 'goodbye') }
     records
   end
 end

--- a/lib/ruby/turbine_rb/lib/turbine_rb/records.rb
+++ b/lib/ruby/turbine_rb/lib/turbine_rb/records.rb
@@ -1,0 +1,126 @@
+require 'json'
+require 'hash_dot'
+
+module TurbineRb
+  class Record
+    attr_accessor :key, :value, :timestamp
+
+    def initialize(pb_record)
+      @key = pb_record.key
+      @timestamp = pb_record.timestamp
+
+      begin
+        @value = JSON.parse(pb_record.value)
+      rescue JSON::ParserError
+        @value = pb_record.value
+      end
+
+      @value = @value.to_dot if is_value_hash?
+    end
+
+    def serialize
+      Io::Meroxa::Funtime::Record.new(key: @key, value: @value.to_json, timestamp: @timestamp)
+    end
+
+    def get(key)
+      if is_value_string? || is_value_array?
+        @value
+      elsif is_cdc_format?
+        @value.send("payload.after.#{key}")
+      else
+        @value.send("payload.#{key}")
+      end
+    end
+
+    def set(key, value)
+      if !is_value_hash?
+        @value = value
+      else
+        payload_key = is_cdc_format? ? "payload.after" : "payload"
+
+        begin
+          @value.send("#{payload_key}.#{key}")
+        rescue NoMethodError
+          schema = @value.send("schema.fields")
+          new_schema_field = { field: key, optional: true, type: "string" }.to_dot
+
+          if is_cdc_format?
+            schema_fields = schema.find { |f| f.field == "after" }
+            schema_fields.fields.unshift(new_schema_field)
+          else
+            schema.unshift(new_schema_field)
+          end
+        end
+
+        @value.send("#{payload_key}.#{key}=", value)
+      end
+    end
+
+    def unwrap!
+      if is_cdc_format?
+        payload = @value.send("payload")
+        schema = @value.send("schema.fields")
+        schema_fields = schema.find { |f| f.field == "after" }
+        if !schema_fields.nil?
+          schema_fields.delete("field")
+          schema_fields.name = @value.send("schema.name")
+          @value.send("schema=", schema_fields)
+        end
+
+        @value.send("payload=", payload.after)
+      end
+    end
+
+    private
+
+    def is_value_string?
+      @value.is_a?(String)
+    end
+
+    def is_value_array?
+      @value.is_a?(Array)
+    end
+
+    def is_value_hash?
+      @value.is_a?(Hash)
+    end
+
+    def is_json_schema?
+      is_value_hash? &&
+      @value.has_key?("payload") &&
+      @value.has_key?("schema")
+    end
+
+    def is_cdc_format?
+      is_json_schema? &&
+      @value.payload.has_key?("source")
+    end
+
+    def type_of_value(value)
+      case value
+      when String
+        "string"
+      when Integer
+        "int32"
+      when Float
+        "float32"
+      when true, false
+        "boolean"
+      else
+        "unsupported"
+      end
+    end
+  end
+
+  class Records < SimpleDelegator
+    def initialize(pb_records)
+      records = pb_records.map { |r| Record.new(r) }
+      __setobj__(records)
+    end
+
+    def unwrap!
+      records = __getobj__
+      records.each { |r| r.unwrap! }
+    end
+  end
+end

--- a/lib/ruby/turbine_rb/spec/turbine_rb_records_spec.rb
+++ b/lib/ruby/turbine_rb/spec/turbine_rb_records_spec.rb
@@ -1,0 +1,141 @@
+RSpec.describe TurbineRb::Record do
+  describe "#serialize" do
+    it "serializes the object to a proto record" do
+      data = { key: "1",  value: { payload: { foo: "bar" }, schema: {} }.to_json, timestamp: Time.now.to_i}
+      pb_record = Io::Meroxa::Funtime::Record.new(data)
+      subject = TurbineRb::Record.new(pb_record)
+      result = subject.serialize
+
+      expect(result).to be_instance_of(Io::Meroxa::Funtime::Record)
+    end
+  end
+
+  context "with cdc formatted json" do
+    let(:data) do
+      {
+        key: "1",
+        value: {
+          payload: {
+            after: {
+              foo: "bar"
+            },
+            source: {}
+          },
+          schema: {
+            fields: [
+              {
+                field: 'after',
+                fields: [
+                  { key: "foo", optional: false, type: "string" }
+                ]
+              }
+            ],
+            name: "schema_name"
+          }
+        }.to_json,
+        timestamp: Time.now.to_i
+      }
+    end
+
+    describe "#get" do
+      it "returns the value at the key" do
+        pb_record = Io::Meroxa::Funtime::Record.new(data)
+        subject = TurbineRb::Record.new(pb_record)
+        result = subject.get("foo")
+
+        expect(result).to eq("bar")
+      end
+    end
+
+    describe "#set" do
+      it "sets the value at the key for an existing key" do
+        pb_record = Io::Meroxa::Funtime::Record.new(data)
+        subject = TurbineRb::Record.new(pb_record)
+        subject.set("foo", "baz")
+        result = subject.value.payload.after.foo
+
+        expect(result).to eq("baz")
+      end
+
+      it "sets the value at the key and adds a schema entry for a new key" do
+        pb_record = Io::Meroxa::Funtime::Record.new(data)
+        subject = TurbineRb::Record.new(pb_record)
+        subject.set("new_foo", "baz")
+        value_result = subject.value.payload.after.new_foo
+        schema_result = subject.value.schema
+          .fields
+          .find { |f| f.field == "after" }
+          .fields
+          .find { |f| f.field == "new_foo" }
+
+        expect(value_result).to eq("baz")
+        expect(schema_result.type).to eq("string")
+      end
+    end
+
+    describe "unwrap!" do
+      it "unwraps cdc formatted data into non cdc format" do
+        pb_record = Io::Meroxa::Funtime::Record.new(data)
+        subject = TurbineRb::Record.new(pb_record)
+        subject.unwrap!
+
+        expect(subject.value.payload.foo).to eq("bar")
+        expect(subject.value.schema.has_key?("field")).to be(false)
+        expect(subject.value.schema.name).to eq("schema_name")
+      end
+    end
+  end
+
+  context "with non cdc formatted json" do
+    let(:data) do
+      {
+        key: "1",
+        value: {
+          payload: {
+            foo: "bar"
+          },
+          schema: {
+            fields: [
+              { key: "foo", optional: false, type: "string" }
+            ]
+          }
+        }.to_json,
+        timestamp: Time.now.to_i
+      }
+    end
+
+    describe "#get" do
+      it "returns the value at the key" do
+        pb_record = Io::Meroxa::Funtime::Record.new(data)
+        subject = TurbineRb::Record.new(pb_record)
+        result = subject.get("foo")
+
+        expect(result).to eq("bar")
+      end
+    end
+
+    describe "#set" do
+      it "sets the value at the key for an existing key" do
+        pb_record = Io::Meroxa::Funtime::Record.new(data)
+        subject = TurbineRb::Record.new(pb_record)
+        subject.set("foo", "baz")
+        result = subject.value.payload.foo
+
+        expect(result).to eq("baz")
+      end
+
+      it "sets the value at the key and adds a schema entry for a new key" do
+        pb_record = Io::Meroxa::Funtime::Record.new(data)
+        subject = TurbineRb::Record.new(pb_record)
+        subject.set("new_foo", "baz")
+        value_result = subject.value.payload.new_foo
+        schema_result = subject.value.schema.fields.find do |f|
+          f.field == "new_foo"
+        end
+
+        expect(value_result).to eq("baz")
+        expect(schema_result.type).to eq("string")
+      end
+    end
+  end
+end

--- a/lib/ruby/turbine_rb/turbine_rb.gemspec
+++ b/lib/ruby/turbine_rb/turbine_rb.gemspec
@@ -31,6 +31,7 @@ Gem::Specification.new do |spec|
   # Uncomment to register a new dependency of your gem
   # spec.add_dependency "example-gem", "~> 1.0"
   spec.add_dependency "grpc", "~> 1.48"
+  spec.add_dependency "hash_dot", "~> 2.5.0"
 
   # For more information and examples about making a new gem, check out our
   # guide at: https://bundler.io/guides/creating_gem.html


### PR DESCRIPTION
+ Modeled after how we expose a record interface in other turbine libs
+ Adds `.get` and `.set` methods to record object to allow reading/writing values (Can be dot separated) 
+ Adds `.unwrap!` to record object for unwrapping CDC payloads
+ Allows user to return `Records` object or Array of Record objects in their function

## Demo

Using:

```
class Masker < TurbineRb::Process
  def call(records:)
    records.each do |r|
      r.set("customer_email", "MASKED")
    end

    records
  end
end
```
Result:
<img width="401" alt="Screen Shot 2022-11-30 at 9 13 12 AM" src="https://user-images.githubusercontent.com/4818826/204818596-650812f4-ba6e-4d54-aaae-0ae080224d75.png">


