### PR TITLE
Check for secret in env for turbine.rb

### DIFF
--- a/lib/ruby/turbine_rb/lib/turbine_rb/client.rb
+++ b/lib/ruby/turbine_rb/lib/turbine_rb/client.rb
@@ -2,6 +2,7 @@
 
 module TurbineRb
   module Client
+    class MissingSecretError < StandardError; end
     class App
       attr_reader :core_server
 
@@ -35,8 +36,11 @@ module TurbineRb
       # register_secrets accepts either a single string or an array of strings
       def register_secrets(secrets)
         [*secrets].map do |secret|
-            req = TurbineCore::Secret.new(name: secret, value: ENV[secret])
-            @core_server.register_secret(req)
+          unless ENV.key?(secret)
+            raise MissingSecretError, "secret #{secret} is not an environment variable"
+          end
+          req = TurbineCore::Secret.new(name: secret, value: ENV[secret])
+          @core_server.register_secret(req)
         end
       end
 

--- a/lib/ruby/turbine_rb/spec/turbine_rb_client_spec.rb
+++ b/lib/ruby/turbine_rb/spec/turbine_rb_client_spec.rb
@@ -71,6 +71,15 @@ RSpec.describe TurbineRb::Client::App do
       end
     end
 
+    it "raises an error when secret is missing from env" do
+      expect {
+        app.register_secrets("FOOBAR")
+      }.to raise_error(
+        TurbineRb::Client::MissingSecretError,
+        /FOOBAR is not an environment variable/
+      )
+    end
+
     it "calls to grpc register_secret using a single secret" do
       user_secret = secrets[0][:name]
       app.register_secrets(user_secret)


### PR DESCRIPTION
Validate when env variable exists before registering secrets.

Before
```
/home/lyubo/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/grpc-1.50.0-x86_64-linux/src/ruby/lib/grpc/generic/active_call.rb:29:in `check_status': 2:invalid Secret.Value: value length must be at least 1 runes. debug_error_string:{UNKNOWN:Error received from peer ipv4:127.0.0.1:50500 {created_time:"2022-11-30T15:31:11.155503127-05:00", grpc_status:2, grpc_message:"invalid Secret.Value: value length must be at least 1 runes"}} (GRPC::Unknown)
```

After
```
client.rb:40:in `block in register_secrets': secret MY_ENV_TEST is not an environment variable (TurbineRb::Client::MissingSecretError)

```