### PR TITLE
fix(turbine_rb): add record interface to local run

### DIFF
--- a/lib/ruby/turbine_rb/lib/turbine_rb/client.rb
+++ b/lib/ruby/turbine_rb/lib/turbine_rb/client.rb
@@ -27,7 +27,9 @@ module TurbineRb
 
         req = TurbineCore::ProcessCollectionRequest.new(collection: unwrapped_records, process: pr)
         @core_server.add_process_to_collection(req)
-        records.pb_collection = process.call(records: records.pb_collection) unless @is_recording
+        records_interface = TurbineRb::Records.new(unwrapped_records.records)
+        processed_records = process.call(records: records_interface) unless @is_recording
+        records.pb_collection = processed_records.map(&:serialize_core_record) unless @is_recording
 
         records
       end


### PR DESCRIPTION
+ Fixes client `process` method to wrap records with Records interface
+ `get` and `set` now appropriately handle freeform json data + a little refactoring

DEMO:
<img width="521" alt="Screen Shot 2022-12-02 at 1 06 31 PM" src="https://user-images.githubusercontent.com/4818826/205368990-0d8d056b-2c10-4830-bc95-feb1b1901f07.png">

Associated function:
```
class Masker < TurbineRb::Process # might be useful to signal that this is a special Turbine call
  def call(records:)
    puts "got records: #{records}"
    records.map { |r| r.set('message', "byeeeeee") }

    records
  end
end
```

With simple ruby app fixture data