### PR TITLE
fix: set new keys on unformatted json

### DIFF
--- a/lib/ruby/turbine_rb/CHANGELOG.md
+++ b/lib/ruby/turbine_rb/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.1.3] - 2022-12-03
+
+- fix: set new keys on unformatted json
+
 ## [0.1.2] - 2022-12-02
 
 - fix: add record interface to local run

--- a/lib/ruby/turbine_rb/lib/turbine_rb/records.rb
+++ b/lib/ruby/turbine_rb/lib/turbine_rb/records.rb
@@ -39,12 +39,14 @@ module TurbineRb
 
     def set(key, value)
       @value = value unless value_hash?
-      return unless value_hash?
+      return @value unless value_hash?
 
-      begin
-        @value.send(payload_key(key))
-      rescue NoMethodError
-        set_schema_field(key, value)
+      if json_schema?
+        begin
+          @value.send(payload_key(key))
+        rescue NoMethodError
+          set_schema_field(key, value)
+        end
       end
 
       @value.send("#{payload_key(key)}=", value)

--- a/lib/ruby/turbine_rb/lib/turbine_rb/version.rb
+++ b/lib/ruby/turbine_rb/lib/turbine_rb/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module TurbineRb
-  VERSION = "0.1.2"
+  VERSION = "0.1.3"
 end

--- a/lib/ruby/turbine_rb/spec/turbine_rb/record_spec.rb
+++ b/lib/ruby/turbine_rb/spec/turbine_rb/record_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe TurbineRb::Record do
     end
   end
 
-  context "with non cdc formatted json" do
+  context "with non cdc formatted json schema" do
     let(:data) do
       {
         key: "1",
@@ -137,6 +137,48 @@ RSpec.describe TurbineRb::Record do
 
         expect(value_result).to eq("baz")
         expect(schema_result.type).to eq("string")
+      end
+    end
+  end
+
+  context "with unstructured json" do
+    let(:data) do
+      {
+        key: "1",
+        value: {
+          message: "hello"
+        }.to_json,
+        timestamp: Time.now.to_i
+      }
+    end
+
+    describe "#get" do
+      it "returns the value at the key" do
+        pb_record = Io::Meroxa::Funtime::Record.new(data)
+        subject = described_class.new(pb_record)
+        result = subject.get("message")
+
+        expect(result).to eq("hello")
+      end
+    end
+
+    describe "#set" do
+      it "sets the value at the key for an existing key" do
+        pb_record = Io::Meroxa::Funtime::Record.new(data)
+        subject = described_class.new(pb_record)
+        subject.set("message", "goodbye")
+        result = subject.value.message
+
+        expect(result).to eq("goodbye")
+      end
+
+      it "sets the value at the key and adds a schema entry for a new key" do
+        pb_record = Io::Meroxa::Funtime::Record.new(data)
+        subject = described_class.new(pb_record)
+        subject.set("new_message", "hey")
+        value_result = subject.value.new_message
+
+        expect(value_result).to eq("hey")
       end
     end
   end


### PR DESCRIPTION
Correct rb to only set schema fields when we detect json schema format

## DEMO 
<img width="577" alt="Screen Shot 2022-12-02 at 4 11 34 PM" src="https://user-images.githubusercontent.com/4818826/205388166-a349ee97-2ae7-4542-8a18-b33ea67dcf56.png">
<img width="484" alt="Screen Shot 2022-12-02 at 4 12 59 PM" src="https://user-images.githubusercontent.com/4818826/205388179-f805472a-ad21-4727-a335-f0a52cc4e4a5.png">
