### PR TITLE
ci: add automated ruby gem release

### DIFF
--- a/.github/workflows/release_ruby.yml
+++ b/.github/workflows/release_ruby.yml
@@ -1,0 +1,54 @@
+name: Release ruby gem
+
+on:
+  push:
+    branches:
+      - main
+jobs:
+  check-local-version:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: lib/ruby/turbine_rb
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.MEROXA_MACHINE }}
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.1.2'
+          bundler-cache: true
+
+      - name: Setup dependencies
+        run: bundler install
+
+      - name: Check local version
+        id: check_local
+        run: echo "local_version=$(bump current)" >> $GITHUB_OUTPUT
+
+      - name: Check published version
+        id: check_published
+        run: echo "published_version=$(gem info turbine_rb -r | grep -o 'turbine_rb \((.*)\)' | tr -d 'turbine_rb ()')" >> $GITHUB_OUTPUT
+
+      - name: Publish
+        if: steps.check_published.outputs.published_version != null && (steps.check_local.outputs.local_version > steps.check_published.outputs.published_version)
+        env:
+          GEM_HOST_API_KEY: "${{secrets.RUBYGEMS_AUTH_TOKEN}}"
+        run: |
+          mkdir -p $HOME/.gem
+          touch $HOME/.gem/credentials
+          chmod 0600 $HOME/.gem/credentials
+          printf -- "---\n:rubygems_api_key: ${GEM_HOST_API_KEY}\n" > $HOME/.gem/credentials
+          gem build *.gemspec
+          gem push *.gem
+
+      - name: Tag
+        with:
+          tag: ${{ format('turbine_rb@{0}', steps.check_local.outputs.local_version) }}
+        run: |
+          git config user.name "${GITHUB_ACTOR}"
+          git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+          git tag -a $INPUT_TAG -m "release: $INPUT_TAG"
+          git push origin $INPUT_TAG
+

--- a/lib/ruby/turbine_rb/Gemfile
+++ b/lib/ruby/turbine_rb/Gemfile
@@ -19,3 +19,5 @@ group :test do
   gem "mocktail"
   gem "rspec", "~> 3.0"
 end
+
+gem "bump", "~> 0.10.0"

--- a/lib/ruby/turbine_rb/Gemfile.lock
+++ b/lib/ruby/turbine_rb/Gemfile.lock
@@ -9,13 +9,22 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.2)
+    bump (0.10.0)
     coderay (1.1.3)
     diff-lcs (1.5.0)
     ffi (1.15.5)
     formatador (1.1.0)
+    google-protobuf (3.21.11)
+    google-protobuf (3.21.11-x86_64-darwin)
     google-protobuf (3.21.11-x86_64-linux)
     googleapis-common-protos-types (1.4.0)
       google-protobuf (~> 3.14)
+    grpc (1.50.0)
+      google-protobuf (~> 3.21)
+      googleapis-common-protos-types (~> 1.0)
+    grpc (1.50.0-x86_64-darwin)
+      google-protobuf (~> 3.21)
+      googleapis-common-protos-types (~> 1.0)
     grpc (1.50.0-x86_64-linux)
       google-protobuf (~> 3.21)
       googleapis-common-protos-types (~> 1.0)
@@ -99,6 +108,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  bump (~> 0.10.0)
   guard-rspec
   mocktail
   pry


### PR DESCRIPTION
+ Added `MEROXA_MACHINE` github machine user token to repo
+ Made sure @meroxa/automation has access to repo
+ Added `RUBYGEMS_AUTH_TOKEN` token to repo
+ Created github action that will detect version changes and publish to ruby gems + tag

## Release Workflow
+ Create a PR with a version bump using `bump patch|minor|major` locally OR manually increment the version (discouraged)
+ Add changelog entry(s) to CHANGELOG.md
+ Get PR approval / merge
+ Gem with a bumped version is automatically published to rubygems
+ Commit is tagged with bumped version