### PR TITLE
turbine-rb: fix collection wrapping/unwrapping

### DIFF
--- a/lib/ruby/turbine_rb/lib/turbine_rb/client.rb
+++ b/lib/ruby/turbine_rb/lib/turbine_rb/client.rb
@@ -30,7 +30,7 @@ module TurbineRb
           )
         )
         records.tap do |r|
-          r.pb_collection = process_call(process: process, pb_collection: pb_collection)
+          r.pb_records = process_call(process: process, pb_collection: pb_collection)
           r.pb_stream = pb_collection.stream
         end
       end
@@ -94,7 +94,7 @@ module TurbineRb
       end
 
       class Collection
-        attr_accessor :pb_collection, :pb_stream, :name, :app
+        attr_accessor :pb_records, :pb_stream, :name, :app
 
         def self.unwrap(collection)
           return collection.unwrap if collection.instance_of?(Collection)
@@ -102,9 +102,9 @@ module TurbineRb
           collection
         end
 
-        def initialize(name, collection, stream, app)
+        def initialize(name, records, stream, app)
           @name = name
-          @pb_collection = collection
+          @pb_records = records
           @pb_stream = stream
           @app = app
         end
@@ -120,7 +120,7 @@ module TurbineRb
         def unwrap
           TurbineCore::Collection.new( # convert back to TurbineCore::Collection
             name: name,
-            records: pb_collection.to_a,
+            records: pb_records.respond_to?(:to_a) ? pb_records.to_a : pb_records,
             stream: pb_stream
           )
         end

--- a/lib/ruby/turbine_rb/spec/turbine_rb/client_spec.rb
+++ b/lib/ruby/turbine_rb/spec/turbine_rb/client_spec.rb
@@ -58,8 +58,8 @@ RSpec.describe TurbineRb::Client::App do
       it "calls the process function on the records in run mode" do
         result = app.process(records: records, process: my_process.new)
 
-        expect(result.pb_collection.first.key).to eq("1")
-        expect(result.pb_collection.first.value).to eq("changedbytes")
+        expect(result.pb_records.first.key).to eq("1")
+        expect(result.pb_records.first.value).to eq("changedbytes")
         expect(result.pb_stream).to eq(records.pb_stream)
       end
 


### PR DESCRIPTION
This should fix the issue experienced in the acceptance tests 

```
=== RUN   TestAppMgmt/RB:_Deploy_app
    turbine_test.go:432: /app/bin/meroxa --cli-config-file /root/meroxa.main.env app deploy --path /apps/turbine_rb/tmp/app/rb-acceptance-app-864f01c9-fe73-4e85-8ba1-535f92df0f0b --spec 0.1.1 --json
    turbine_test.go:432: 	✔ Checked your language is "ruby"
        	✔ Checked your application name is "rb-acceptance-app-864f01c9-fe73-4e85-8ba1-535f92df0f0b"
        /usr/local/lib/ruby/gems/3.1.0/gems/turbine_rb-0.2.1/lib/turbine_rb/client.rb:123:in `method_missing': undefined method `to_a' for <TurbineCore::Collection: name: "", stream: "", records: []>:TurbineCore::Collection (NoMethodError)
                    records: pb_collection.to_a,
                                          ^^^^^
        Did you mean?  to_h
                       to_s
        	from /usr/local/lib/ruby/gems/3.1.0/gems/turbine_rb-0.2.1/lib/turbine_rb/client.rb:123:in `unwrap'
        	from /usr/local/lib/ruby/gems/3.1.0/gems/turbine_rb-0.2.1/lib/turbine_rb/client.rb:78:in `write'
        	from /apps/turbine_rb/tmp/app/rb-acceptance-app-864f01c9-fe73-4e85-8ba1-535f92df0f0b/app.rb:19:in `call'
        	from /usr/local/lib/ruby/gems/3.1.0/gems/turbine_rb-0.2.1/lib/turbine_rb.rb:52:in `record'
        	from -e:1:in `<main>'
        exit status 1
        Error: exit status 1
        
    turbine_test.go:442: exit status 1
```