### PR TITLE
turbine-rb: ensure records is an array

### DIFF
--- a/lib/ruby/turbine_rb/lib/turbine_rb/client.rb
+++ b/lib/ruby/turbine_rb/lib/turbine_rb/client.rb
@@ -117,10 +117,16 @@ module TurbineRb
           app.process(records: self, process: process)
         end
 
+        def records
+          return pb_records.to_a if pb_records.respond_to?(:to_a)
+
+          [pb_records].compact.flatten
+        end
+
         def unwrap
           TurbineCore::Collection.new( # convert back to TurbineCore::Collection
             name: name,
-            records: pb_records.respond_to?(:to_a) ? pb_records.to_a : pb_records,
+            records: records,
             stream: pb_stream
           )
         end

--- a/lib/ruby/turbine_rb/lib/turbine_rb/version.rb
+++ b/lib/ruby/turbine_rb/lib/turbine_rb/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module TurbineRb
-  VERSION = "0.2.2"
+  VERSION = "0.2.3"
 end


### PR DESCRIPTION
Another error

```
/usr/local/lib/ruby/gems/3.1.0/gems/turbine_rb-0.2.2/lib/turbine_rb/client.rb:121:in `initialize': Expected array as initializer value for repeated field 'records' (given TurbineCore::Collection). (ArgumentError)
        	from /usr/local/lib/ruby/gems/3.1.0/gems/turbine_rb-0.2.2/lib/turbine_rb/client.rb:121:in `new'
        	from /usr/local/lib/ruby/gems/3.1.0/gems/turbine_rb-0.2.2/lib/turbine_rb/client.rb:121:in `unwrap'
        	from /usr/local/lib/ruby/gems/3.1.0/gems/turbine_rb-0.2.2/lib/turbine_rb/client.rb:78:in `write'
        	from /apps/turbine_rb/tmp/app/rb-acceptance-app-1d0e52a8-7399-4a8b-8113-cbdc12b7c9d5/app.rb:19:in `call'
        	from /usr/local/lib/ruby/gems/3.1.0/gems/turbine_rb-0.2.2/lib/turbine_rb.rb:52:in `record'
        	from -e:1:in `<main>'
```