### PR TITLE
turbine-rb: fix bug, process_call should be returning records

### DIFF
--- a/lib/ruby/turbine_rb/Gemfile.lock
+++ b/lib/ruby/turbine_rb/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    turbine_rb (0.2.1)
+    turbine_rb (0.2.3)
       grpc (~> 1.48)
       hash_dot (~> 2.5.0)
 
@@ -14,9 +14,9 @@ GEM
     diff-lcs (1.5.0)
     ffi (1.15.5)
     formatador (1.1.0)
-    google-protobuf (3.21.11)
-    google-protobuf (3.21.11-x86_64-darwin)
-    google-protobuf (3.21.11-x86_64-linux)
+    google-protobuf (3.21.12)
+    google-protobuf (3.21.12-x86_64-darwin)
+    google-protobuf (3.21.12-x86_64-linux)
     googleapis-common-protos-types (1.4.0)
       google-protobuf (~> 3.14)
     grpc (1.50.0)

--- a/lib/ruby/turbine_rb/lib/turbine_rb/client.rb
+++ b/lib/ruby/turbine_rb/lib/turbine_rb/client.rb
@@ -36,7 +36,7 @@ module TurbineRb
       end
 
       def process_call(process:, pb_collection:)
-        return pb_collection if recording?
+        return pb_collection.records if recording?
 
         process
           .call(records: TurbineRb::Records.new(pb_collection.records))

--- a/lib/ruby/turbine_rb/lib/turbine_rb/version.rb
+++ b/lib/ruby/turbine_rb/lib/turbine_rb/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module TurbineRb
-  VERSION = "0.2.3"
+  VERSION = "0.2.4"
 end

--- a/pkg/ir/spec.go
+++ b/pkg/ir/spec.go
@@ -3,6 +3,7 @@ package ir
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 	"sync"
 
 	"github.com/heimdalr/dag"
@@ -23,6 +24,11 @@ const (
 
 	LatestSpecVersion = "0.2.0"
 )
+
+var specVersions = []string{
+	"0.1.1",
+	LatestSpecVersion,
+}
 
 type DeploymentSpec struct {
 	mu          sync.Mutex
@@ -71,11 +77,18 @@ type TurbineSpec struct {
 	Version  string `json:"version"`
 }
 
-func ValidateSpecVersion(specVersion string) error {
-	if specVersion != LatestSpecVersion {
-		return fmt.Errorf("spec version %q is not a supported. use version %q instead", specVersion, LatestSpecVersion)
+func ValidateSpecVersion(ver string) error {
+	for _, v := range specVersions {
+		if v == ver {
+			return nil
+		}
 	}
-	return nil
+
+	return fmt.Errorf(
+		"spec version %q is invalid, supported versions: %s",
+		ver,
+		strings.Join(specVersions, ", "),
+	)
 }
 
 func (d *DeploymentSpec) SetImageForFunctions(image string) {


### PR DESCRIPTION
 /usr/local/lib/ruby/gems/3.1.0/gems/turbine_rb-0.2.3/lib/turbine_rb/client.rb:127:in `initialize': Invalid type TurbineCore::Collection to assign to submessage field 'records'. (Google::Protobuf::TypeError)
        	from /usr/local/lib/ruby/gems/3.1.0/gems/turbine_rb-0.2.3/lib/turbine_rb/client.rb:127:in `new'
        	from /usr/local/lib/ruby/gems/3.1.0/gems/turbine_rb-0.2.3/lib/turbine_rb/client.rb:127:in `unwrap'
        	from /usr/local/lib/ruby/gems/3.1.0/gems/turbine_rb-0.2.3/lib/turbine_rb/client.rb:78:in `write'
        	from /apps/turbine_rb/tmp/app/rb-acceptance-app-38359f2a-8746-45ed-83e2-11e0a4085b6c/app.rb:19:in `call'
        	from /usr/local/lib/ruby/gems/3.1.0/gems/turbine_rb-0.2.3/lib/turbine_rb.rb:52:in `record'
        	from -e:1:in `<main>'
        exit status 1