### PR TITLE
Remove pattern check for stream name

### DIFF
--- a/pkg/ir/schema.json
+++ b/pkg/ir/schema.json
@@ -104,7 +104,7 @@
                     "properties": {
                         "name": {
                             "type": "string",
-                            "pattern": "^[a-zA-Z][a-zA-Z0-9-_]*$"
+                            "minLength": 1
                         },
                         "from_uuid": {
                             "type": "string",


### PR DESCRIPTION
We need to remove pattern check for stream names since stream names are currently comprised of two uuid concatenated. Since uuids can start with numbers, this pattern sometimes fails:

```
1. spec: ""/streams/0/name" field fails /properties/streams/items/0/properties/name/pattern validation: does not match pattern '^[a-zA-Z][a-zA-Z0-9-_]*$'"
``` 