### PR TITLE
Deprecate `environment` from app config

### DIFF
--- a/lib/ruby/turbine_rb/README.md
+++ b/lib/ruby/turbine_rb/README.md
@@ -167,7 +167,6 @@ This file contains all of the options for configuring a Turbine app. Upon initia
 {
   "name": "testapp",
   "language": "ruby",
-  "environment": "common",
   "resources": {
     "source_name": "fixtures/path"
   }
@@ -176,8 +175,13 @@ This file contains all of the options for configuring a Turbine app. Upon initia
 
 * `name` - The name of your application. This should not change after app initialization.
 * `language` - Tells Meroxa what language the app is upon deployment.
-* `environment` - "common" is the only available environment. Meroxa does have the ability to create isolated environments but this feature is currently in beta.
 * `resources` - These are the named integrations that you'll use in your application. The `source_name` needs to match the name of the resource that you'll set up in Meroxa using the `meroxa resources create` command or via the Dashboard. You can point to the path in the fixtures that'll be used to mock the resource when you run `meroxa apps run`.
+
+#### Deprecated
+
+These fields have been deprecated and won't be used.
+
+* `environment` - "common" is the only available environment. Meroxa does have the ability to create isolated environments but this feature is currently in beta.
 
 ### Fixtures
 

--- a/pkg/app/config.go
+++ b/pkg/app/config.go
@@ -11,7 +11,6 @@ import (
 
 type Config struct {
 	Name        string            `json:"name"`
-	Environment string            `json:"environment"`
 	Pipeline    string            `json:"pipeline"` // TODO: Eventually remove support for providing a pipeline if we need to
 	Resources   map[string]string `json:"resources"`
 	Language    string            `json:"language"`

--- a/pkg/app/config_test.go
+++ b/pkg/app/config_test.go
@@ -27,6 +27,11 @@ func Test_ReadConfig(t *testing.T) {
 			appPath: setupAppJson(t),
 		},
 		{
+			desc:    "reads a valid app config with deprecated fields",
+			appName: "new-name-app",
+			appPath: setupAppJsonWithDeprecatedFields(t),
+		},
+		{
 			desc:    "fails to read an config with missing app name",
 			appPath: setupAppJsonMissingField(t),
 			errmsg:  "application name is required",
@@ -63,7 +68,6 @@ func setupAppJson(t *testing.T) string {
 		[]byte(`{
 				  "name": "testapp",
 				  "language": "golang",
-				  "environment": "common",
 				  "resources": {
 				    "source_name": "fixtures/demo-cdc.json"
 				  }
@@ -76,13 +80,33 @@ func setupAppJson(t *testing.T) string {
 	return tmpdir
 }
 
+func setupAppJsonWithDeprecatedFields(t *testing.T) string {
+	tmpdir := t.TempDir()
+	if err := os.WriteFile(
+		path.Join(tmpdir, "app.json"),
+		[]byte(`{
+				  "name": "testapp",
+				  "language": "golang",
+				  "environment": "foobar",
+				  "resources": {
+				    "source_name": "fixtures/demo-cdc.json"
+				  }
+				}`),
+		0644,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	return tmpdir
+}
+
+
 func setupAppJsonMissingField(t *testing.T) string {
 	tmpdir := t.TempDir()
 	if err := os.WriteFile(
 		path.Join(tmpdir, "app.json"),
 		[]byte(`{
 				  "language": "golang",
-				  "environment": "common",
 				  "resources": {
 				    "source_name": "fixtures/demo-cdc.json"
 				  }

--- a/pkg/app/templates/ruby/app.json
+++ b/pkg/app/templates/ruby/app.json
@@ -1,7 +1,6 @@
 {
     "name": "{{.AppName}}",
     "language": "ruby",
-    "environment": "common",
     "resources": {
         "demopg": "fixtures/demo.json"
     }

--- a/pkg/server/run_test.go
+++ b/pkg/server/run_test.go
@@ -106,7 +106,6 @@ func Test_Init(t *testing.T) {
 				assert.Equal(t, s.appPath, req.ConfigFilePath)
 				assert.Equal(t, s.config, app.Config{
 					Name:        "app",
-					Environment: "common",
 					Pipeline:    "turbine-pipeline-app",
 					Resources: map[string]string{
 						"demopg": "fixtures/demo.json",


### PR DESCRIPTION
Remove `environment` variable from app config and add note about deprecation.

Fixes #82 