### PR TITLE
Automerge Dependabot PRs with passing automation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,51 @@
+# Docs: https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates
+version: 2
+updates:
+
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: ".github:"
+
+  # Maintain dependencies for Go
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "go.mod:"
+  - package-ecosystem: "gomod"
+    directory: "/lib/go"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "go.mod:"
+
+  # Maintain dependencies for Node
+  - package-ecosystem: "npm"
+    directory: "/lib/typescript"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "package.json:"
+
+  # Maintain dependencies for Python
+  - package-ecosystem: "pip"
+    directory: "/lib/python"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "requirements:"
+
+
+  # Maintain dependencies for Ruby
+  - package-ecosystem: "bundler"
+    directory: "/lib/ruby/turbine_rb"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "Gemfile:"
+

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,39 @@
+# This action automatically merges dependabot PRs that update go dependencies (only patch and minor updates).
+# Based on: https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/automating-dependabot-with-github-actions#enable-auto-merge-on-a-pull-request 
+
+name: Dependabot auto-merge
+on:
+  pull_request:
+    # Run this action when dependabot labels the PR, we care about the 'go' label.
+    types: [labeled]
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  dependabot-go:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' && contains(github.event.pull_request.labels.*.name, 'go') }}
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v1.3.6
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Approve PR
+        # Approve only patch and minor updates
+        if: ${{ steps.metadata.outputs.update-type != 'version-update:semver-major' }}
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge for Dependabot PRs
+        # Enable auto-merging only for patch and minor updates
+        if: ${{ steps.metadata.outputs.update-type != 'version-update:semver-major' }}
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -4,7 +4,7 @@
 name: Dependabot auto-merge
 on:
   pull_request:
-    # Run this action when dependabot labels the PR, we care about the 'go' label.
+    # Run this action when dependabot labels the PR.
     types: [labeled]
 
 permissions:
@@ -14,7 +14,7 @@ permissions:
 jobs:
   dependabot-go:
     runs-on: ubuntu-latest
-    if: ${{ github.actor == 'dependabot[bot]' && contains(github.event.pull_request.labels.*.name, 'go') }}
+    if: ${{ github.actor == 'dependabot[bot]'}}
     steps:
       - name: Dependabot metadata
         id: metadata


### PR DESCRIPTION
## Description of change

Keep up to date automatically as long as dependency updates don't break anything

Related to https://github.com/meroxa/engineering/issues/51

## Type of change

<!-- Please tick off the correct checkbox after saving the PR description. -->

- [x]  New feature
- [ ]  Bug fix
- [ ]  Refactor
- [ ]  Documentation

## How was this tested?

- [x]  Unit Tests
- [ ]  Tested in staging
- [ ]  Tested in minikube

## Demo

<!-- Provide examples of how the feature looked before and after this change in the table below -->
| before | after |
|--------|-------|
|<!-- Replace this with a screenshot/gif -->|<!-- Replace this with a screenshot/gif -->|


## Additional references

<!-- Post any additional links (if appropriate) below -->

## Documentation updated

<!-- Make sure that our [documentation](https://docs.meroxa.com/) is accordingly updated when necessary.

You can do that by opening a pull-request to our (🔒 private, for now) repository: https://github.com/meroxa/meroxa-docs.

✨ In the future, there will be a GitHub action taking care of these updates automatically. ✨ -->

<!-- Provide a PR link below -->
