### PR TITLE
Refactor record service; rename to spec builder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,14 @@ gomod:
 vet:
 	go vet ./...
 
+.PHONY: gofumpt
+gofumpt:
+	go install mvdan.cc/gofumpt@latest
+
+.PHONY: fmt
+fmt: gofumpt
+	gofumpt -l -w .
+
 .PHONY: test
 test: vet
 	go test `go list ./... | grep -v 'turbine-core\/pkg\/app\/templates\/go'` \

--- a/pkg/app/config.go
+++ b/pkg/app/config.go
@@ -4,10 +4,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/meroxa/turbine-core/pkg/ir"
 	"log"
 	"os"
 	"path"
+
+	"github.com/meroxa/turbine-core/pkg/ir"
 )
 
 type Config struct {

--- a/pkg/app/config_test.go
+++ b/pkg/app/config_test.go
@@ -100,7 +100,6 @@ func setupAppJsonWithDeprecatedFields(t *testing.T) string {
 	return tmpdir
 }
 
-
 func setupAppJsonMissingField(t *testing.T) string {
 	tmpdir := t.TempDir()
 	if err := os.WriteFile(

--- a/pkg/app/config_test.go
+++ b/pkg/app/config_test.go
@@ -72,7 +72,7 @@ func setupAppJson(t *testing.T) string {
 				    "source_name": "fixtures/demo-cdc.json"
 				  }
 				}`),
-		0644,
+		0o644,
 	); err != nil {
 		t.Fatal(err)
 	}
@@ -92,7 +92,7 @@ func setupAppJsonWithDeprecatedFields(t *testing.T) string {
 				    "source_name": "fixtures/demo-cdc.json"
 				  }
 				}`),
-		0644,
+		0o644,
 	); err != nil {
 		t.Fatal(err)
 	}
@@ -110,7 +110,7 @@ func setupAppJsonMissingField(t *testing.T) string {
 				    "source_name": "fixtures/demo-cdc.json"
 				  }
 				}`),
-		0644,
+		0o644,
 	); err != nil {
 		t.Fatal(err)
 	}
@@ -123,7 +123,7 @@ func setupBadAppJson(t *testing.T) string {
 	if err := os.WriteFile(
 		path.Join(tmpdir, "app.json"),
 		[]byte(`invalid-json`),
-		0644,
+		0o644,
 	); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/app/init.go
+++ b/pkg/app/init.go
@@ -2,12 +2,13 @@ package app
 
 import (
 	"embed"
-	"github.com/meroxa/turbine-core/pkg/ir"
 	"log"
 	"os"
 	"path/filepath"
 	"strings"
 	"text/template"
+
+	"github.com/meroxa/turbine-core/pkg/ir"
 )
 
 type AppInit struct {
@@ -25,14 +26,14 @@ type AppInitTemplate struct {
 var templateFS embed.FS
 
 func (a *AppInit) createAppDirectory() error {
-	return os.MkdirAll(filepath.Join(a.Path, a.AppName), 0755)
+	return os.MkdirAll(filepath.Join(a.Path, a.AppName), 0o755)
 }
 
 // createFixtures will create exclusively a fixtures folder and its content
 func (a *AppInit) createFixtures() error {
 	directory := "fixtures"
 
-	err := os.Mkdir(filepath.Join(a.Path, a.AppName, directory), 0755)
+	err := os.Mkdir(filepath.Join(a.Path, a.AppName, directory), 0o755)
 	if err != nil {
 		return err
 	}

--- a/pkg/ir/schema.go
+++ b/pkg/ir/schema.go
@@ -3,13 +3,12 @@ package ir
 import (
 	_ "embed"
 	"encoding/json"
+
 	"github.com/santhosh-tekuri/jsonschema/v5"
 )
 
-var (
-	//go:embed schema.json
-	turbineIRSchema string
-)
+//go:embed schema.json
+var turbineIRSchema string
 
 func ValidateSpec(spec []byte, specVersion string) error {
 	err := ValidateSpecVersion(specVersion)

--- a/pkg/ir/spec.go
+++ b/pkg/ir/spec.go
@@ -4,15 +4,17 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/google/uuid"
 	"strings"
 	"sync"
 
+	"github.com/google/uuid"
 	"github.com/heimdalr/dag"
 )
 
-type ConnectorType string
-type Lang string
+type (
+	ConnectorType string
+	Lang          string
+)
 
 const (
 	GoLang     Lang = "golang"

--- a/pkg/ir/spec.go
+++ b/pkg/ir/spec.go
@@ -95,10 +95,18 @@ func ValidateSpecVersion(ver string) error {
 	)
 }
 
-func (d *DeploymentSpec) SetImageForFunctions(image string) {
+func (d *DeploymentSpec) SetImageForFunctions(image string) error {
+	switch {
+	case image == "" && len(d.Functions) > 0:
+		return fmt.Errorf("empty image for functions")
+	case image != "" && len(d.Functions) == 0:
+		return fmt.Errorf("cannot set image without defined functions")
+	}
+
 	for i := range d.Functions {
 		d.Functions[i].Image = image
 	}
+	return nil
 }
 
 func (d *DeploymentSpec) Marshal() ([]byte, error) {

--- a/pkg/ir/spec_test.go
+++ b/pkg/ir/spec_test.go
@@ -180,7 +180,6 @@ func Test_DeploymentSpec(t *testing.T) {
 	}
 
 	assert.Equal(t, deploySpec, expectedSpec)
-
 }
 
 func Test_ValidateVersion(t *testing.T) {

--- a/pkg/server/record.go
+++ b/pkg/server/record.go
@@ -3,7 +3,6 @@ package server
 import (
 	"context"
 	"strings"
-	//"fmt"
 
 	"github.com/google/uuid"
 	pb "github.com/meroxa/turbine-core/lib/go/github.com/meroxa/turbine/core"
@@ -38,8 +37,8 @@ func (s *specBuilderService) Init(_ context.Context, req *pb.InitRequest) (*empt
 		GitSha: req.GetGitSHA(),
 		Metadata: ir.MetadataSpec{
 			Turbine: ir.TurbineSpec{
-				Language: ir.Lang(strings.ToLower(req.GetLanguage().String())),
-				Version:  req.GetTurbineVersion(),
+				Language: ir.Lang(strings.ToLower(req.Language.String())),
+				Version:  req.TurbineVersion,
 			},
 			SpecVersion: ir.LatestSpecVersion,
 		},

--- a/pkg/server/record.go
+++ b/pkg/server/record.go
@@ -2,8 +2,8 @@ package server
 
 import (
 	"context"
-	"fmt"
 	"strings"
+	//"fmt"
 
 	"github.com/google/uuid"
 	pb "github.com/meroxa/turbine-core/lib/go/github.com/meroxa/turbine/core"
@@ -12,29 +12,34 @@ import (
 	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
-type recordService struct {
+var _ pb.TurbineServiceServer = (*specBuilderService)(nil)
+
+type specBuilderService struct {
 	pb.UnimplementedTurbineServiceServer
-	deploymentSpec *ir.DeploymentSpec
-	resources      []*pb.Resource
+
+	spec      *ir.DeploymentSpec
+	resources []*pb.Resource
 }
 
-func NewRecordService() *recordService {
-	return &recordService{
-		deploymentSpec: &ir.DeploymentSpec{},
+func NewSpecBuilderService() *specBuilderService {
+	return &specBuilderService{
+		spec: &ir.DeploymentSpec{
+			Secrets: make(map[string]string),
+		},
 	}
 }
 
-func (s *recordService) Init(_ context.Context, request *pb.InitRequest) (*emptypb.Empty, error) {
-	if err := request.Validate(); err != nil {
+func (s *specBuilderService) Init(_ context.Context, req *pb.InitRequest) (*emptypb.Empty, error) {
+	if err := req.Validate(); err != nil {
 		return nil, err
 	}
 
-	s.deploymentSpec.Definition = ir.DefinitionSpec{
-		GitSha: request.GetGitSHA(),
+	s.spec.Definition = ir.DefinitionSpec{
+		GitSha: req.GetGitSHA(),
 		Metadata: ir.MetadataSpec{
 			Turbine: ir.TurbineSpec{
-				Language: ir.Lang(strings.ToLower(request.GetLanguage().String())),
-				Version:  request.GetTurbineVersion(),
+				Language: ir.Lang(strings.ToLower(req.GetLanguage().String())),
+				Version:  req.GetTurbineVersion(),
 			},
 			SpecVersion: ir.LatestSpecVersion,
 		},
@@ -42,89 +47,69 @@ func (s *recordService) Init(_ context.Context, request *pb.InitRequest) (*empty
 	return empty(), nil
 }
 
-func (s *recordService) GetResource(_ context.Context, request *pb.GetResourceRequest) (*pb.Resource, error) {
-	r := &pb.Resource{
-		Name: request.GetName(),
+func (s *specBuilderService) GetResource(_ context.Context, req *pb.GetResourceRequest) (*pb.Resource, error) {
+	if err := req.Validate(); err != nil {
+		return nil, err
 	}
-	return r, nil
+	return &pb.Resource{Name: req.Name}, nil
 }
 
-func resourceConfigsToMap(configs []*pb.Config) map[string]interface{} {
-	m := make(map[string]interface{})
-	for _, rc := range configs {
-		m[rc.GetField()] = rc.GetValue()
-	}
-	return m
-}
-
-func (s *recordService) ReadCollection(_ context.Context, request *pb.ReadCollectionRequest) (*pb.Collection, error) {
-	if request.GetCollection() == "" {
-		return &pb.Collection{}, fmt.Errorf("please provide a collection name to 'read'")
+func (s *specBuilderService) ReadCollection(_ context.Context, req *pb.ReadCollectionRequest) (*pb.Collection, error) {
+	if err := req.Validate(); err != nil {
+		return nil, err
 	}
 
 	s.resources = append(s.resources, &pb.Resource{
-		Name:       request.GetResource().GetName(),
+		Name:       req.GetResource().GetName(),
 		Source:     true,
-		Collection: request.GetCollection(),
+		Collection: req.GetCollection(),
 	})
 
-	for _, c := range s.deploymentSpec.Connectors {
-		// Only one source per app allowed.
-		if c.Type == ir.ConnectorSource {
-			return &pb.Collection{}, fmt.Errorf("only one call to 'read' is allowed per Meroxa Data Application")
-		}
-	}
-
-	sourceConnector := ir.ConnectorSpec{
+	c := ir.ConnectorSpec{
 		UUID:       uuid.New().String(),
-		Collection: request.GetCollection(),
-		Resource:   request.Resource.GetName(),
+		Collection: req.Collection,
+		Resource:   req.Resource.Name,
 		Type:       ir.ConnectorSource,
-		Config:     resourceConfigsToMap(request.GetConfigs().GetConfig()),
+		Config:     configMap(req.Configs),
 	}
 
-	if err := s.deploymentSpec.AddSource(&sourceConnector); err != nil {
+	if err := s.spec.AddSource(&c); err != nil {
 		return nil, err
 	}
 
 	return &pb.Collection{
-		Name:   request.Collection,
-		Stream: sourceConnector.UUID,
+		Name:   req.Collection,
+		Stream: c.UUID,
 	}, nil
 }
 
-func (s *recordService) WriteCollectionToResource(_ context.Context, request *pb.WriteCollectionRequest) (*emptypb.Empty, error) {
-	// This function may be called zero or more times.
-	if request.GetTargetCollection() == "" {
-		return empty(), fmt.Errorf("please provide a collection name to 'write'")
-	}
-	source := request.GetSourceCollection()
-	if source == nil {
-		return empty(), fmt.Errorf("please provide a collection name to 'write' from ")
+func (s *specBuilderService) WriteCollectionToResource(_ context.Context, req *pb.WriteCollectionRequest) (*emptypb.Empty, error) {
+	if err := req.Validate(); err != nil {
+		return nil, err
 	}
 
 	s.resources = append(s.resources, &pb.Resource{
-		Name:        request.GetResource().GetName(),
+		Name:        req.Resource.Name,
 		Destination: true,
-		Collection:  request.TargetCollection,
+		Collection:  req.TargetCollection,
 	})
 
-	destinationConnector := ir.ConnectorSpec{
+	c := ir.ConnectorSpec{
 		UUID:       uuid.New().String(),
-		Collection: request.GetTargetCollection(),
-		Resource:   request.GetResource().GetName(),
+		Collection: req.TargetCollection,
+		Resource:   req.Resource.Name,
 		Type:       ir.ConnectorDestination,
-		Config:     resourceConfigsToMap(request.GetConfigs().GetConfig()),
+		Config:     configMap(req.Configs),
 	}
-	if err := s.deploymentSpec.AddDestination(&destinationConnector); err != nil {
+	if err := s.spec.AddDestination(&c); err != nil {
 		return nil, err
 	}
 
-	if err := s.deploymentSpec.AddStream(&ir.StreamSpec{
+	if err := s.spec.AddStream(&ir.StreamSpec{
 		UUID:     uuid.New().String(),
-		FromUUID: source.Stream,
-		ToUUID:   destinationConnector.UUID,
-		Name:     source.Stream + "_" + destinationConnector.UUID,
+		FromUUID: req.SourceCollection.Stream,
+		ToUUID:   c.UUID,
+		Name:     req.SourceCollection.Stream + "_" + c.UUID,
 	}); err != nil {
 		return nil, err
 	}
@@ -132,68 +117,79 @@ func (s *recordService) WriteCollectionToResource(_ context.Context, request *pb
 	return empty(), nil
 }
 
-func (s *recordService) AddProcessToCollection(_ context.Context, request *pb.ProcessCollectionRequest) (*pb.Collection, error) {
-	p := request.GetProcess()
-
-	collection := request.GetCollection()
-	function := ir.FunctionSpec{
-		Name: strings.ToLower(p.GetName()),
-		UUID: uuid.New().String(),
-	}
-
-	if err := s.deploymentSpec.AddFunction(&function); err != nil {
+func (s *specBuilderService) AddProcessToCollection(_ context.Context, req *pb.ProcessCollectionRequest) (*pb.Collection, error) {
+	if err := req.Validate(); err != nil {
 		return nil, err
 	}
 
-	if err := s.deploymentSpec.AddStream(&ir.StreamSpec{
+	f := ir.FunctionSpec{
+		UUID: uuid.New().String(),
+		Name: strings.ToLower(req.Process.Name),
+	}
+	if err := s.spec.AddFunction(&f); err != nil {
+		return nil, err
+	}
+
+	if err := s.spec.AddStream(&ir.StreamSpec{
 		UUID:     uuid.New().String(),
-		FromUUID: collection.Stream,
-		ToUUID:   function.UUID,
-		Name:     collection.Stream + "_" + function.UUID,
+		FromUUID: req.Collection.Stream,
+		ToUUID:   f.UUID,
+		Name:     req.Collection.Stream + "_" + f.UUID,
 	}); err != nil {
 		return nil, err
 	}
 
 	return &pb.Collection{
-		Name:   collection.Name,
-		Stream: function.UUID,
+		Name:   req.Collection.Name,
+		Stream: f.UUID,
 	}, nil
 }
 
-func (s *recordService) RegisterSecret(_ context.Context, secret *pb.Secret) (*emptypb.Empty, error) {
-	if s.deploymentSpec.Secrets == nil {
-		s.deploymentSpec.Secrets = map[string]string{}
+func (s *specBuilderService) RegisterSecret(_ context.Context, secret *pb.Secret) (*emptypb.Empty, error) {
+	if err := secret.Validate(); err != nil {
+		return nil, err
 	}
-	s.deploymentSpec.Secrets[secret.Name] = secret.Value
+	s.spec.Secrets[secret.Name] = secret.Value
 	return empty(), nil
 }
 
-func (s *recordService) HasFunctions(_ context.Context, _ *emptypb.Empty) (*wrapperspb.BoolValue, error) {
-	return wrapperspb.Bool(len(s.deploymentSpec.Functions) > 0), nil
+func (s *specBuilderService) HasFunctions(_ context.Context, _ *emptypb.Empty) (*wrapperspb.BoolValue, error) {
+	return wrapperspb.Bool(len(s.spec.Functions) > 0), nil
 }
 
-func (s *recordService) ListResources(_ context.Context, _ *emptypb.Empty) (*pb.ListResourcesResponse, error) {
+func (s *specBuilderService) ListResources(_ context.Context, _ *emptypb.Empty) (*pb.ListResourcesResponse, error) {
 	return &pb.ListResourcesResponse{Resources: s.resources}, nil
 }
 
-func (s *recordService) GetSpec(_ context.Context, in *pb.GetSpecRequest) (*pb.GetSpecResponse, error) {
-	if image := in.GetImage(); image != "" {
-		if len(s.deploymentSpec.Functions) == 0 {
-			return nil, fmt.Errorf("cannot set function image since spec has no functions")
-		}
-		s.deploymentSpec.SetImageForFunctions(image)
-	}
-
-	if _, err := s.deploymentSpec.BuildDAG(); err != nil {
+func (s *specBuilderService) GetSpec(_ context.Context, req *pb.GetSpecRequest) (*pb.GetSpecResponse, error) {
+	if err := req.Validate(); err != nil {
 		return nil, err
 	}
 
-	spec, err := s.deploymentSpec.Marshal()
-	if err != nil {
-		return &pb.GetSpecResponse{}, err
+	if err := s.spec.SetImageForFunctions(req.Image); err != nil {
+		return nil, err
 	}
 
-	return &pb.GetSpecResponse{
-		Spec: spec,
-	}, nil
+	if _, err := s.spec.BuildDAG(); err != nil {
+		return nil, err
+	}
+
+	spec, err := s.spec.Marshal()
+	if err != nil {
+		return nil, err
+	}
+
+	return &pb.GetSpecResponse{Spec: spec}, nil
+}
+
+func configMap(configs *pb.Configs) map[string]any {
+	if configs == nil {
+		return nil
+	}
+
+	m := make(map[string]any)
+	for _, c := range configs.Config {
+		m[c.Field] = c.Value
+	}
+	return m
 }

--- a/pkg/server/record_test.go
+++ b/pkg/server/record_test.go
@@ -186,11 +186,14 @@ func TestWriteCollectionToResource(t *testing.T) {
 		{
 			description: "empty request",
 			req:         &pb.WriteCollectionRequest{},
-			errMsg:      "please provide a collection name to 'write'",
+			errMsg:      "invalid WriteCollectionRequest.Resource: value is required",
 		},
 		{
 			description: "specBuilderService has existing connector",
 			req: &pb.WriteCollectionRequest{
+				Resource: &pb.Resource{
+					Name: "pg",
+				},
 				TargetCollection: "accounts_copy",
 				Configs:          nil,
 			},
@@ -213,6 +216,9 @@ func TestWriteCollectionToResource(t *testing.T) {
 		{
 			description: "successfully store destination information with config",
 			req: &pb.WriteCollectionRequest{
+				Resource: &pb.Resource{
+					Name: "pg",
+				},
 				TargetCollection: "accounts_copy",
 				Configs: &pb.Configs{
 					Config: []*pb.Config{

--- a/pkg/server/record_test.go
+++ b/pkg/server/record_test.go
@@ -84,10 +84,8 @@ func TestInit(t *testing.T) {
 			} else {
 				require.ErrorContains(t, err, test.want.Error())
 			}
-
 		})
 	}
-
 }
 
 func TestGetResource(t *testing.T) {
@@ -111,7 +109,6 @@ func TestReadCollection(t *testing.T) {
 		want            *ir.DeploymentSpec
 		errMsg          string
 	}{
-
 		{
 			description: "successfully store source information",
 			req: &pb.ReadCollectionRequest{
@@ -172,7 +169,6 @@ func TestReadCollection(t *testing.T) {
 			}
 		})
 	}
-
 }
 
 func TestWriteCollectionToResource(t *testing.T) {
@@ -285,7 +281,6 @@ func TestWriteCollectionToResource(t *testing.T) {
 			}
 		})
 	}
-
 }
 
 func TestAddProcessToCollection(t *testing.T) {
@@ -303,7 +298,6 @@ func TestAddProcessToCollection(t *testing.T) {
 
 	read, err := s.ReadCollection(ctx,
 		&pb.ReadCollectionRequest{
-
 			Collection: "accounts",
 			Resource: &pb.Resource{
 				Name:       "pg",
@@ -330,7 +324,6 @@ func TestAddProcessToCollection(t *testing.T) {
 	require.Equal(t, s.spec.Functions[0].Name, want.Functions[0].Name)
 	require.Equal(t, s.spec.Streams[0].FromUUID, read.Stream)
 	require.Equal(t, s.spec.Streams[0].ToUUID, res.Stream)
-
 }
 
 func TestRegisterSecret(t *testing.T) {
@@ -361,7 +354,6 @@ func TestRegisterSecret(t *testing.T) {
 	require.Nil(t, err)
 	require.Equal(t, empty(), res)
 	require.Equal(t, want.Secrets, s.spec.Secrets)
-
 }
 
 func TestHasFunctions(t *testing.T) {

--- a/pkg/server/run.go
+++ b/pkg/server/run.go
@@ -92,8 +92,7 @@ func (s *runService) AddProcessToCollection(ctx context.Context, req *pb.Process
 	if err := req.Validate(); err != nil {
 		return nil, err
 	}
-
-	return req.GetCollection(), nil
+	return req.Collection, nil
 }
 
 func (s *runService) RegisterSecret(ctx context.Context, req *pb.Secret) (*emptypb.Empty, error) {

--- a/pkg/server/run_test.go
+++ b/pkg/server/run_test.go
@@ -5,11 +5,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/meroxa/turbine-core/pkg/ir"
 	"io"
 	"os"
 	"path"
 	"testing"
+
+	"github.com/meroxa/turbine-core/pkg/ir"
 
 	pb "github.com/meroxa/turbine-core/lib/go/github.com/meroxa/turbine/core"
 	"github.com/meroxa/turbine-core/pkg/app"
@@ -83,7 +84,7 @@ func Test_Init(t *testing.T) {
 								"demopg": "fixtures/demo.json"
 							}
 						}`, ir.Ruby)),
-						0644,
+						0o644,
 					),
 				)
 
@@ -356,7 +357,7 @@ func Test_ReadCollection(t *testing.T) {
 								"timestamp": "1662758822"
 							}]
 						}`),
-						0644,
+						0o644,
 					),
 				)
 				return &pb.ReadCollectionRequest{

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -25,10 +25,14 @@ func NewRunServer() *turbineCoreServer {
 	return &turbineCoreServer{Server: s}
 }
 
-func NewRecordServer() *turbineCoreServer {
+func NewSpecBuilderServer() *turbineCoreServer {
 	s := grpc.NewServer()
-	pb.RegisterTurbineServiceServer(s, NewRecordService())
+	pb.RegisterTurbineServiceServer(s, NewSpecBuilderService())
 	return &turbineCoreServer{Server: s}
+}
+
+func NewRecordServer() *turbineCoreServer {
+	return NewSpecBuilderServer()
 }
 
 func (s *turbineCoreServer) Run(ctx context.Context) {


### PR DESCRIPTION
## Description of change

Small refactor in the record service to make use of the validation rules in the proto.
Rename the `record` to be `spec builder` instead, more clarity.

Part of https://github.com/meroxa/turbine-core/issues/107

## Type of change

<!-- Please tick off the correct checkbox after saving the PR description. -->

- [ ]  New feature
- [ ]  Bug fix
- [x]  Refactor
- [ ]  Documentation

## How was this tested?

- [x]  Unit Tests
- [ ]  Tested in staging
- [ ]  Tested in minikube

## Demo

<!-- Provide examples of how the feature looked before and after this change in the table below -->
| before | after |
|--------|-------|
|<!-- Replace this with a screenshot/gif -->|<!-- Replace this with a screenshot/gif -->|


## Additional references

<!-- Post any additional links (if appropriate) below -->

## Documentation updated

<!-- Make sure that our [documentation](https://docs.meroxa.com/) is accordingly updated when necessary.

You can do that by opening a pull-request to our (🔒 private, for now) repository: https://github.com/meroxa/meroxa-docs.

✨ In the future, there will be a GitHub action taking care of these updates automatically. ✨ -->

<!-- Provide a PR link below -->
