### PR TITLE
fix: add back shorthand validations

### DIFF
--- a/pkg/ir/schema.json
+++ b/pkg/ir/schema.json
@@ -157,7 +157,9 @@
                                     "enum": [
                                         "golang",
                                         "javascript",
+                                        "js",
                                         "python",
+                                        "py",
                                         "ruby"
                                     ]
                                 },

--- a/pkg/ir/schema_test.go
+++ b/pkg/ir/schema_test.go
@@ -541,7 +541,7 @@ func Test_ValidSpec(t *testing.T) {
 						"metadata": {
 							"turbine": {
 								"version": "1.5.1",
-								"language": "python"
+								"language": "py"
 							},
 							"spec_version": "0.2.0"
 						}


### PR DESCRIPTION
## Description of change
Oh boy, how much time do you have? 

See https://meroxa.slack.com/archives/C03F15EKFU3/p1682697464659729

Adding back shorthand names, since we rely on them for older specs.

## Type of change

<!-- Please tick off the correct checkbox after saving the PR description. -->

- [ ]  New feature
- [x]  Bug fix
- [ ]  Refactor
- [ ]  Documentation

## How was this tested?
Changed 1 of 2 python tests to use the shorthand
- [x]  Unit Tests
- [ ]  Tested in staging
- [ ]  Tested in minikube