### PR TITLE
fix: update turbine-py for non IR

### DIFF
--- a/pkg/app/templates/python/main.py
+++ b/pkg/app/templates/python/main.py
@@ -3,8 +3,8 @@ import logging
 import sys
 import pdb
 
-from turbine.src.turbine_app import RecordList
-from turbine.src.turbine_app import TurbineApp
+from turbine.runtime import RecordList
+from turbine.runtime import Runtime
 
 logging.basicConfig(level=logging.INFO)
 
@@ -30,7 +30,7 @@ def anonymize(records: RecordList) -> RecordList:
 
 class App:
     @staticmethod
-    async def run(turbine: TurbineApp):
+    async def run(turbine: Runtime):
         try:
             # To configure your data stores as resources on the Meroxa Platform
             # use the Meroxa Dashboard, CLI, or Meroxa Terraform Provider.

--- a/pkg/app/templates/python/requirements.txt
+++ b/pkg/app/templates/python/requirements.txt
@@ -1,4 +1,4 @@
-turbine-py==1.5.1
+turbine-py==1.8.1
 aiohttp>=3.8.1
 grpcio>=1.44.0
 grpcio-tools>=1.44.0


### PR DESCRIPTION
## Description of change
While we wait to ship IR, the apps initialized with turbine-core in python do not match the deploy and run

## Type of change

<!-- Please tick off the correct checkbox after saving the PR description. -->

- [ ]  New feature
- [x]  Bug fix
- [ ]  Refactor
- [ ]  Documentation
