### PR TITLE
fix: ensure embedded subdirectory dotfiles are included

### DIFF
--- a/pkg/app/init.go
+++ b/pkg/app/init.go
@@ -23,7 +23,7 @@ type AppInitTemplate struct {
 	AppName string
 }
 
-//go:embed templates/*
+//go:embed all:templates
 var templateFS embed.FS
 
 func (a *AppInit) createAppDirectory() error {

--- a/pkg/app/init_test.go
+++ b/pkg/app/init_test.go
@@ -223,7 +223,7 @@ func TestAppInit_listTemplateContent(t *testing.T) {
 				Language: ir.GoLang,
 				Path:     t.TempDir(),
 			},
-			want:  []string{"README.md", "app.go", "app.json", "app_test.go"},
+			want:  []string{".gitignore", "README.md", "app.go", "app.json", "app_test.go"},
 			want1: []string{"fixtures"},
 		},
 		{
@@ -233,7 +233,7 @@ func TestAppInit_listTemplateContent(t *testing.T) {
 				Language: ir.JavaScript,
 				Path:     t.TempDir(),
 			},
-			want:  []string{"README.md", "app.json", "index.js", "index.test.js", "package.json"},
+			want:  []string{".gitignore", "README.md", "app.json", "index.js", "index.test.js", "package.json"},
 			want1: []string{"fixtures"},
 		},
 	}


### PR DESCRIPTION
## Description of change

<!-- Provide a brief description of the change, what it is and why it was made below.* -->
https://pkg.go.dev/embed

Added the tag to ensure that dotfiles in subdirectories would be included. 

## Type of change

<!-- Please tick off the correct checkbox after saving the PR description. -->

- [ ]  New feature
- [x]  Bug fix
- [ ]  Refactor
- [ ]  Documentation

## How was this tested?

- [x]  Unit Tests
- [ ]  Tested in staging
- [ ]  Tested in minikube