### PR TITLE
[Stateful Stream Processing] Remove connector count validations

### DIFF
--- a/pkg/ir/schema.json
+++ b/pkg/ir/schema.json
@@ -41,29 +41,7 @@
                     ]
                 }
             ],
-            "contains": {
-                "type": "object",
-                "properties": {
-                    "collection": {
-                        "type": "string"
-                    },
-                    "type": {
-                        "type": "string",
-                        "pattern": "^source$"
-                    },
-                    "resource": {
-                        "type": "string"
-                    },
-                    "config": {
-                        "type": "object"
-                    }
-                },
-                "required": [
-                    "type"
-                ]
-            },
-            "maxContains": 1,
-            "minItems": 1,
+            "minItems": 0,
             "uniqueItems": true
         },
         "functions": {

--- a/pkg/ir/schema_test.go
+++ b/pkg/ir/schema_test.go
@@ -118,7 +118,6 @@ func Test_ValidSpec(t *testing.T) {
 					}
 				}
 			}`,
-			err: "\"/connectors\" field fails /properties/connectors/minItems validation: minimum 1 items required, but found 0 items",
 		},
 		{
 			desc:        "empty connector",
@@ -188,7 +187,6 @@ func Test_ValidSpec(t *testing.T) {
 							}
 						}
 					}`,
-			err: "\"/connectors/0/type\" field fails /properties/connectors/contains/properties/type/pattern validation: does not match pattern '^source$'",
 		},
 		{
 			desc:        "one source, one destination connectors",
@@ -290,7 +288,6 @@ func Test_ValidSpec(t *testing.T) {
 							}
 						}
 					}`,
-			err: "\"/connectors\" field fails /properties/connectors/maxContains validation: valid must be <= 1, but got 2",
 		},
 		{
 			desc:        "one source, two duplicate destination connectors",

--- a/pkg/ir/schema_test.go
+++ b/pkg/ir/schema_test.go
@@ -102,7 +102,7 @@ func Test_ValidSpec(t *testing.T) {
 					}`,
 		},
 		{
-			desc:        "connectors list",
+			desc:        "allow an empty connectors list",
 			specVersion: "0.2.0",
 			spec: `{
 				"connectors": [
@@ -165,7 +165,7 @@ func Test_ValidSpec(t *testing.T) {
 			err: "\"/connectors/0/type\" field fails /properties/connectors/items/0/properties/type/enum validation: value must be one of \"source\", \"destination\"",
 		},
 		{
-			desc:        "one destination connector",
+			desc:        "allow one destination connector",
 			specVersion: "0.2.0",
 			spec: `{
 						"connectors": [
@@ -254,7 +254,7 @@ func Test_ValidSpec(t *testing.T) {
 					}`,
 		},
 		{
-			desc:        "two source, one destination connectors",
+			desc:        "allow multiple sources, one destination connectors",
 			specVersion: "0.2.0",
 			spec: `{
 						"connectors": [


### PR DESCRIPTION
## Description of change

The connector count/type validation logic is being moved to the libraries that are generating the IR spec. 

This removes the following requirements:
- Only one source connector is allowed
- At least one connector of any type is required 

Fixes https://github.com/meroxa/product/issues/899

## Type of change

<!-- Please tick off the correct checkbox after saving the PR description. -->

- [ ]  New feature
- [ ]  Bug fix
- [x]  Refactor
- [ ]  Documentation

## How was this tested?

- [x]  Unit Tests
- [ ]  Tested in staging
- [ ]  Tested in minikube

## Demo

<!-- Provide examples of how the feature looked before and after this change in the table below -->
| before | after |
|--------|-------|
|<!-- Replace this with a screenshot/gif -->|<!-- Replace this with a screenshot/gif -->|


## Additional references

<!-- Post any additional links (if appropriate) below -->

## Documentation updated

<!-- Make sure that our [documentation](https://docs.meroxa.com/) is accordingly updated when necessary.

You can do that by opening a pull-request to our (🔒 private, for now) repository: https://github.com/meroxa/meroxa-docs.

✨ In the future, there will be a GitHub action taking care of these updates automatically. ✨ -->

<!-- Provide a PR link below -->
