### PR TITLE
[Stateful Stream Processing] Relax Root Number Validation in IR

### DIFF
--- a/pkg/ir/spec.go
+++ b/pkg/ir/spec.go
@@ -227,7 +227,7 @@ func (d *DeploymentSpec) BuildDAG() (*dag.DAG, error) {
 		}
 	}
 
-	return turbineDag, d.ValidateDAG(turbineDag)
+	return turbineDag, nil
 }
 
 // upgradeToLatestSpecVersion will ensure that simple topologies as defined in 0.1.1 are still compatible

--- a/pkg/ir/spec.go
+++ b/pkg/ir/spec.go
@@ -131,9 +131,6 @@ func (d *DeploymentSpec) AddSource(c *ConnectorSpec) error {
 	defer d.mu.Unlock()
 	d.init()
 
-	if len(d.turbineDag.GetRoots()) >= 1 {
-		return fmt.Errorf("can only add one source connector per application")
-	}
 	if c.Type != ConnectorSource {
 		return fmt.Errorf("not a source connector")
 	}

--- a/pkg/ir/spec_test.go
+++ b/pkg/ir/spec_test.go
@@ -1244,7 +1244,10 @@ func Test_Scenario10(t *testing.T) {
 		},
 	)
 	require.NoError(t, err)
-	_, err = spec.BuildDAG()
+	dag, err := spec.BuildDAG()
+	require.NoError(t, err)
+
+	err = spec.ValidateDAG(dag)
 	require.Error(t, err)
 	assert.Equal(t, err.Error(), "invalid DAG, too many sources")
 }
@@ -1306,11 +1309,19 @@ func Test_ValidateDAG(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			spec := tc.spec
-			_, err := spec.BuildDAG()
-			if tc.wantError != nil {
-				assert.Equal(t, err.Error(), tc.wantError.Error())
+			dag, buildError := spec.BuildDAG()
+			if tc.wantError != nil && buildError != nil {
+				assert.Equal(t, tc.wantError.Error(), buildError.Error())
+				return
 			} else {
-				assert.NoError(t, err)
+				assert.NoError(t, buildError)
+			}
+
+			validateError := spec.ValidateDAG(dag)
+			if tc.wantError != nil {
+				assert.Equal(t, tc.wantError.Error(), validateError.Error())
+			} else {
+				assert.NoError(t, validateError)
 			}
 		})
 	}

--- a/pkg/ir/spec_test.go
+++ b/pkg/ir/spec_test.go
@@ -296,7 +296,7 @@ func Test_MarshalUnmarshal(t *testing.T) {
 	require.Equal(t, spec, got)
 }
 
-func Test_EnsureSingleSource(t *testing.T) {
+func Test_AllowMultipleSources(t *testing.T) {
 	var spec ir.DeploymentSpec
 	err := spec.AddSource(
 		&ir.ConnectorSpec{
@@ -312,7 +312,7 @@ func Test_EnsureSingleSource(t *testing.T) {
 	require.NoError(t, err)
 	err = spec.AddSource(
 		&ir.ConnectorSpec{
-			UUID:       "1",
+			UUID:       "2",
 			Collection: "accounts2",
 			Resource:   "mongo",
 			Type:       ir.ConnectorSource,
@@ -321,7 +321,36 @@ func Test_EnsureSingleSource(t *testing.T) {
 			},
 		},
 	)
-	require.EqualError(t, err, fmt.Errorf("can only add one source connector per application").Error())
+	require.NoError(t, err)
+}
+
+func Test_EnsureNonDuplicateSources(t *testing.T) {
+	var spec ir.DeploymentSpec
+	err := spec.AddSource(
+		&ir.ConnectorSpec{
+			UUID:       "1",
+			Collection: "accounts",
+			Resource:   "mongo",
+			Type:       ir.ConnectorSource,
+			Config: map[string]interface{}{
+				"config": "value",
+			},
+		},
+	)
+	require.NoError(t, err)
+
+	duplicate := &ir.ConnectorSpec{
+		UUID:       "1",
+		Collection: "accounts2",
+		Resource:   "mongo",
+		Type:       ir.ConnectorSource,
+		Config: map[string]interface{}{
+			"config": "value",
+		},
+	}
+
+	err = spec.AddSource(duplicate)
+	require.EqualError(t, err, fmt.Errorf("the id '%s' is already known", duplicate.UUID).Error())
 }
 
 func Test_BadStream(t *testing.T) {


### PR DESCRIPTION
## Description of change

Relaxes root validation for sources. In addition this change also removes `ValidateDAG()` from the `BuildDAG()` function. It is now intended for callers to invoke both `ValidateDAG()` and `BuildDAG()` independently 

Fixes https://github.com/meroxa/product/issues/902

## Type of change

<!-- Please tick off the correct checkbox after saving the PR description. -->

- [ ]  New feature
- [ ]  Bug fix
- [x]  Refactor
- [ ]  Documentation

## How was this tested?

- [x]  Unit Tests
- [ ]  Tested in staging
- [ ]  Tested in minikube

## Demo

<!-- Provide examples of how the feature looked before and after this change in the table below -->
| before | after |
|--------|-------|
|<!-- Replace this with a screenshot/gif -->|<!-- Replace this with a screenshot/gif -->|


## Additional references

<!-- Post any additional links (if appropriate) below -->

## Documentation updated

<!-- Make sure that our [documentation](https://docs.meroxa.com/) is accordingly updated when necessary.

You can do that by opening a pull-request to our (🔒 private, for now) repository: https://github.com/meroxa/meroxa-docs.

✨ In the future, there will be a GitHub action taking care of these updates automatically. ✨ -->

<!-- Provide a PR link below -->
