### PR TITLE
Better error message for missing resource in app.json

### DIFF
--- a/pkg/server/run.go
+++ b/pkg/server/run.go
@@ -9,6 +9,8 @@ import (
 	"github.com/meroxa/turbine-core/pkg/server/internal"
 
 	pb "github.com/meroxa/turbine-core/lib/go/github.com/meroxa/turbine/core"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/emptypb"
 )
 
@@ -59,7 +61,13 @@ func (s *runService) ReadCollection(ctx context.Context, req *pb.ReadCollectionR
 
 	fixtureFile, ok := s.config.Resources[req.Resource.Name]
 	if !ok {
-		return nil, fmt.Errorf("No fixture file found for resource %s. Ensure that the resource is declared in your app.json.", req.Resource.Name)
+		return nil, status.Error(
+			codes.InvalidArgument,
+			fmt.Sprintf(
+				"No fixture file found for resource %s. Ensure that the resource is declared in your app.json.",
+				req.Resource.Name,
+			),
+		)
 	}
 
 	fixture := &internal.FixtureResource{

--- a/pkg/server/run.go
+++ b/pkg/server/run.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"fmt"
 	"path"
 
 	"github.com/meroxa/turbine-core/pkg/app"
@@ -56,11 +57,16 @@ func (s *runService) ReadCollection(ctx context.Context, req *pb.ReadCollectionR
 		return nil, err
 	}
 
+	fixtureFile, ok := s.config.Resources[req.Resource.Name]
+	if !ok {
+		return nil, fmt.Errorf("No fixture file found for resource %s. Ensure that the resource is declared in your app.json.", req.Resource.Name)
+	}
+
 	fixture := &internal.FixtureResource{
 		Collection: req.Collection,
 		File: path.Join(
 			s.appPath,
-			s.config.Resources[req.Resource.Name],
+			fixtureFile,
 		),
 	}
 

--- a/pkg/server/run_test.go
+++ b/pkg/server/run_test.go
@@ -369,6 +369,41 @@ func Test_ReadCollection(t *testing.T) {
 				}
 			},
 		},
+		{
+			desc: "wrong fixture resource name",
+			srv: &runService{
+				appPath: path.Join(tempdir),
+				config: app.Config{
+					Resources: map[string]string{
+						"resource123": "fixture.json",
+					},
+				},
+			},
+			wantErr: errors.New("No fixture file found for resource pg"),
+			setup: func() *pb.ReadCollectionRequest {
+				file := path.Join(tempdir, "fixture.json")
+				require.NoError(
+					t,
+					os.WriteFile(
+						file,
+						[]byte(`{
+							"events": [{
+								"key": "1",
+								"value": {"message":"hello"},
+								"timestamp": "1662758822"
+							}]
+						}`),
+						0o644,
+					),
+				)
+				return &pb.ReadCollectionRequest{
+					Resource: &pb.Resource{
+						Name: "pg",
+					},
+					Collection: "events",
+				}
+			},
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
## Description of change

Improves an error message around missing resource names in the fixtures section of `app.json`.

Fixes https://github.com/meroxa/product/issues/954

## Type of change

- [ ]  New feature
- [x]  Bug fix
- [ ]  Refactor
- [ ]  Documentation

## How was this tested?

- [x]  Unit Tests
- [x]  Manual tests
- [ ]  Tested in staging
- [ ]  Tested in minikube

## Demo

## Before

```bash
~/go/src/notion-s3 main
❯ meroxa apps run --debug

2023/08/02 16:34:52 rpc error: code = Unknown desc = read /Users/samir/go/src/notion-s3: is a directory

Error: exit status 1
```
## After

```bash
~/go/src/notion-s3 main
❯ ../cli/meroxa apps run --debug
Error: 2023/08/03 13:12:13 rpc error: code = InvalidArgument desc = No fixture file found for resource notion. Ensure that the resource is declared in your app.json.
exit status 1

```
