### PR TITLE
feat: recursive apps init

### DIFF
--- a/pkg/app/init.go
+++ b/pkg/app/init.go
@@ -2,11 +2,11 @@ package app
 
 import (
 	"embed"
+	"io"
 	"log"
 	"os"
 	"path"
 	"path/filepath"
-	"strings"
 	"text/template"
 
 	"github.com/meroxa/turbine-core/pkg/ir"
@@ -26,38 +26,16 @@ type AppInitTemplate struct {
 //go:embed all:templates
 var templateFS embed.FS
 
-func (a *AppInit) createAppDirectory() error {
-	return os.MkdirAll(filepath.Join(a.Path, a.AppName), 0o755)
+func NewAppInit(appName string, language ir.Lang, path string) *AppInit {
+	return &AppInit{
+		AppName:  appName,
+		Language: language,
+		Path:     path,
+	}
 }
 
-// createFixtures will create exclusively a fixtures folder and its content
-func (a *AppInit) createFixtures() error {
-	directory := "fixtures"
-
-	err := os.Mkdir(filepath.Join(a.Path, a.AppName, directory), 0o755)
-	if err != nil {
-		return err
-	}
-
-	content, err := templateFS.ReadDir(path.Join("templates", string(a.Language), directory))
-	if err != nil {
-		return err
-	}
-
-	for _, f := range content {
-		if !f.IsDir() && strings.Contains(f.Name(), "json") {
-			if err = a.duplicateFile("fixtures/" + f.Name()); err != nil {
-				return err
-			}
-		}
-	}
-
-	return nil
-}
-
-// duplicateFile reads from a template and write to a file located to a path provided by the user
-func (a *AppInit) duplicateFile(fileName string) error {
-	t, err := template.ParseFS(templateFS, path.Join("templates", string(a.Language), fileName))
+func (a *AppInit) applytemplate(srcDir, destDir, fileName string) error {
+	t, err := template.ParseFS(templateFS, path.Join(srcDir, fileName))
 	if err != nil {
 		return err
 	}
@@ -65,7 +43,8 @@ func (a *AppInit) duplicateFile(fileName string) error {
 	appTrait := AppInitTemplate{
 		AppName: a.AppName,
 	}
-	f, err := os.Create(filepath.Join(a.Path, a.AppName, fileName))
+
+	f, err := os.Create(filepath.Join(destDir, fileName))
 	if err != nil {
 		return err
 	}
@@ -77,18 +56,51 @@ func (a *AppInit) duplicateFile(fileName string) error {
 		}
 	}(f)
 
-	err = t.Execute(f, appTrait)
+	return t.Execute(f, appTrait)
+}
+
+// copyFile simply copies the file from srcDir to destDir (without applying a template)
+func (a *AppInit) copyFile(srcDir, destDir, fileName string) error {
+	srcPath := filepath.Join(srcDir, fileName)
+	destPath := filepath.Join(destDir, fileName)
+
+	srcFile, err := templateFS.Open(srcPath)
 	if err != nil {
 		return err
 	}
+	defer srcFile.Close()
+
+	destFile, err := os.Create(destPath)
+	if err != nil {
+		return err
+	}
+	defer destFile.Close()
+
+	_, err = io.Copy(destFile, srcFile)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 
-// listTemplateContent is used to return existing files and directories on a given path
-func (a *AppInit) listTemplateContent() ([]string, []string, error) {
+func (a *AppInit) duplicateFileInPath(srcDir, destDir, fileName string) error {
+	notTemplateExtensions := []string{".jar"}
+
+	fExtension := filepath.Ext(fileName)
+	for _, ext := range notTemplateExtensions {
+		if fExtension == ext {
+			return a.copyFile(srcDir, destDir, fileName)
+		}
+	}
+	return a.applytemplate(srcDir, destDir, fileName)
+}
+
+// listTemplateContentFromPath is used to return existing files and directories on a given path
+func (a *AppInit) listTemplateContentFromPath(srcPath string) ([]string, []string, error) {
 	var files, directories []string
 
-	content, err := templateFS.ReadDir(path.Join("templates", string(a.Language)))
+	content, err := templateFS.ReadDir(srcPath)
 	if err != nil {
 		return files, directories, err
 	}
@@ -103,38 +115,39 @@ func (a *AppInit) listTemplateContent() ([]string, []string, error) {
 	return files, directories, nil
 }
 
-func NewAppInit(appName string, language ir.Lang, path string) *AppInit {
-	return &AppInit{
-		AppName:  appName,
-		Language: language,
-		Path:     path,
-	}
-}
-
-// Init will be used from the CLI to generate a new application directory based on the existing
-// content on `/templates`.
-func (a *AppInit) Init() error {
-	err := a.createAppDirectory()
+func (a *AppInit) duplicateDirectory(srcDir, destDir string) error {
+	// Create source directory
+	err := os.MkdirAll(destDir, 0o755)
 	if err != nil {
 		return err
 	}
 
-	files, _, err := a.listTemplateContent()
-	if err != nil {
-		return err
-	}
+	files, directories, err := a.listTemplateContentFromPath(srcDir)
 
-	for _, f := range files {
-		err := a.duplicateFile(f)
+	for _, fileName := range files {
+		err = a.duplicateFileInPath(srcDir, destDir, fileName)
 		if err != nil {
 			return err
 		}
 	}
 
-	// TODO: Maybe write a recursive function that could take care of nested directories like this one
-	err = a.createFixtures()
-	if err != nil {
-		return err
+	for _, d := range directories {
+		subSrcDir := filepath.Join(srcDir, d)
+		subDestDir := filepath.Join(destDir, d)
+		err = a.duplicateDirectory(subSrcDir, subDestDir)
+		if err != nil {
+			return err
+		}
 	}
+
 	return nil
+}
+
+// Init will be used from the CLI to generate a new application directory based on the existing
+// content on `/templates`.
+func (a *AppInit) Init() error {
+	rootSrcDir := filepath.Join("templates", string(a.Language))
+	rootDestDir := filepath.Join(a.Path, a.AppName)
+
+	return a.duplicateDirectory(rootSrcDir, rootDestDir)
 }

--- a/pkg/app/init_test.go
+++ b/pkg/app/init_test.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -8,122 +9,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 )
-
-func TestAppInit_createAppDirectory(t *testing.T) {
-	type fields struct {
-		AppName  string
-		Language ir.Lang
-		Path     string
-	}
-	tests := []struct {
-		name    string
-		fields  fields
-		wantErr bool
-	}{
-		{
-			name: "creates the ruby app directory",
-			fields: fields{
-				AppName:  "createappdir",
-				Language: ir.Ruby,
-				Path:     t.TempDir(),
-			},
-			wantErr: false,
-		},
-		{
-			name: "creates the go app directory",
-			fields: fields{
-				AppName:  "createappdir",
-				Language: ir.GoLang,
-				Path:     t.TempDir(),
-			},
-			wantErr: false,
-		},
-		{
-			name: "creates the js app directory",
-			fields: fields{
-				AppName:  "createappdir",
-				Language: ir.JavaScript,
-				Path:     t.TempDir(),
-			},
-			wantErr: false,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			a := &AppInit{
-				AppName:  tt.fields.AppName,
-				Language: tt.fields.Language,
-				Path:     tt.fields.Path,
-			}
-			if err := a.createAppDirectory(); (err != nil) != tt.wantErr {
-				t.Errorf("AppInit.createAppDirectory() error = %v, wantErr %v", err, tt.wantErr)
-			}
-
-			require.DirExists(t, filepath.Join(tt.fields.Path, tt.fields.AppName))
-		})
-	}
-}
-
-func TestAppInit_createFixtures(t *testing.T) {
-	type fields struct {
-		AppName  string
-		Language ir.Lang
-		Path     string
-	}
-	tests := []struct {
-		name    string
-		fields  fields
-		want    string
-		wantErr bool
-	}{
-		{
-			name: "creates the ruby fixtures directory",
-			fields: fields{
-				AppName:  "createfixtures",
-				Language: ir.Ruby,
-				Path:     t.TempDir(),
-			},
-			want:    "demo.json",
-			wantErr: false,
-		},
-		{
-			name: "creates the go fixtures directory",
-			fields: fields{
-				AppName:  "createfixtures",
-				Language: ir.GoLang,
-				Path:     t.TempDir(),
-			},
-			want:    "demo-cdc.json",
-			wantErr: false,
-		},
-		{
-			name: "creates the js fixtures directory",
-			fields: fields{
-				AppName:  "createfixtures",
-				Language: ir.JavaScript,
-				Path:     t.TempDir(),
-			},
-			want:    "demo-cdc.json",
-			wantErr: false,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			a := &AppInit{
-				AppName:  tt.fields.AppName,
-				Language: tt.fields.Language,
-				Path:     tt.fields.Path,
-			}
-
-			a.createAppDirectory()
-			if err := a.createFixtures(); (err != nil) != tt.wantErr {
-				t.Errorf("AppInit.createFixtures() error = %v, wantErr %v", err, tt.wantErr)
-			}
-			require.DirExists(t, filepath.Join(tt.fields.Path, tt.fields.AppName, "fixtures"))
-			require.FileExists(t, filepath.Join(tt.fields.Path, tt.fields.AppName, "fixtures", tt.want))
-		})
-	}
-}
 
 func TestAppInit_duplicateFile(t *testing.T) {
 	type fields struct {
@@ -184,8 +69,11 @@ func TestAppInit_duplicateFile(t *testing.T) {
 				Language: tt.fields.Language,
 				Path:     tt.fields.Path,
 			}
-			a.createAppDirectory()
-			if err := a.duplicateFile(tt.args.fileName); (err != nil) != tt.wantErr {
+			srcPath := filepath.Join("templates", string(a.Language))
+			dstPath := filepath.Join(a.Path, a.AppName)
+
+			os.MkdirAll(dstPath, 0o755)
+			if err := a.duplicateFileInPath(srcPath, dstPath, tt.args.fileName); (err != nil) != tt.wantErr {
 				t.Errorf("AppInit.duplicateFile() error = %v, wantErr %v", err, tt.wantErr)
 			}
 			require.FileExists(t, filepath.Join(tt.fields.Path, tt.fields.AppName, tt.args.fileName))
@@ -193,7 +81,9 @@ func TestAppInit_duplicateFile(t *testing.T) {
 	}
 }
 
-func TestAppInit_listTemplateContent(t *testing.T) {
+func TestAppInit_listTemplateContentFrompath(t *testing.T) {
+	const appName = "testapp"
+
 	type fields struct {
 		AppName  string
 		Language ir.Lang
@@ -209,7 +99,7 @@ func TestAppInit_listTemplateContent(t *testing.T) {
 		{
 			name: "lists files and dir content for ruby app embedded template",
 			fields: fields{
-				AppName:  "testapp",
+				AppName:  appName,
 				Language: ir.Ruby,
 				Path:     t.TempDir(),
 			},
@@ -219,7 +109,7 @@ func TestAppInit_listTemplateContent(t *testing.T) {
 		{
 			name: "lists files and dir content for go app embedded template",
 			fields: fields{
-				AppName:  "testapp",
+				AppName:  appName,
 				Language: ir.GoLang,
 				Path:     t.TempDir(),
 			},
@@ -229,7 +119,7 @@ func TestAppInit_listTemplateContent(t *testing.T) {
 		{
 			name: "lists files and dir content for js app embedded template",
 			fields: fields{
-				AppName:  "testapp",
+				AppName:  appName,
 				Language: ir.JavaScript,
 				Path:     t.TempDir(),
 			},
@@ -244,7 +134,7 @@ func TestAppInit_listTemplateContent(t *testing.T) {
 				Language: tt.fields.Language,
 				Path:     tt.fields.Path,
 			}
-			got, got1, err := a.listTemplateContent()
+			got, got1, err := a.listTemplateContentFromPath(filepath.Join("templates", string(a.Language)))
 			if (err != nil) != tt.wantErr {
 				t.Errorf("AppInit.listTemplateContent() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -256,51 +146,82 @@ func TestAppInit_listTemplateContent(t *testing.T) {
 	}
 }
 
+type directory struct {
+	name    string
+	subDirs []directory
+	files   []string
+}
+
 func TestAppInit_Init(t *testing.T) {
+	const appName = "testapp"
+
 	type fields struct {
 		AppName  string
 		Language ir.Lang
 		Path     string
 	}
 	tests := []struct {
-		name            string
-		fields          fields
-		wantFiles       []string
-		wantFixtureFile string
-		wantErr         bool
+		name      string
+		fields    fields
+		wantFiles directory
+		wantErr   bool
 	}{
 		{
 			name: "copies the ruby app template to the path",
 			fields: fields{
-				AppName:  "testapp",
+				AppName:  appName,
 				Language: ir.Ruby,
 				Path:     t.TempDir(),
 			},
-			wantFiles:       []string{"app.json", "app.rb", "Gemfile"},
-			wantFixtureFile: "demo.json",
-			wantErr:         false,
+			wantFiles: directory{
+				name: appName,
+				subDirs: []directory{
+					{
+						name:  "fixtures",
+						files: []string{"demo.json"},
+					},
+				},
+				files: []string{"app.json", "app.rb", "Gemfile"},
+			},
+			wantErr: false,
 		},
 		{
 			name: "copies the go app template to the path",
 			fields: fields{
-				AppName:  "testapp",
+				AppName:  appName,
 				Language: ir.GoLang,
 				Path:     t.TempDir(),
 			},
-			wantFiles:       []string{"app.json", "app_test.go", "app.go", "README.md"},
-			wantFixtureFile: "demo-no-cdc.json",
-			wantErr:         false,
+			wantFiles: directory{
+				name: appName,
+				subDirs: []directory{
+					{
+						name:  "fixtures",
+						files: []string{"demo-no-cdc.json"},
+					},
+				},
+				files: []string{"app.json", "app_test.go", "app.go", "README.md"},
+			},
+			wantErr: false,
 		},
 		{
-			name: "copies the go app template to the path",
+			name: "copies the js app template to the path",
 			fields: fields{
-				AppName:  "testapp",
+				AppName:  appName,
 				Language: ir.JavaScript,
 				Path:     t.TempDir(),
 			},
-			wantFiles:       []string{"app.json", "package.json", "index.js", "index.test.js", "README.md"},
-			wantFixtureFile: "demo-no-cdc.json",
-			wantErr:         false,
+			wantFiles: directory{
+				name: appName,
+				subDirs: []directory{
+					{
+						name:  "fixtures",
+						files: []string{"demo-no-cdc.json"},
+					},
+				},
+				files: []string{"app.json", "package.json", "index.js", "index.test.js", "README.md"},
+			},
+			wantErr: false,
 		},
 	}
 	for _, tt := range tests {
@@ -313,12 +234,20 @@ func TestAppInit_Init(t *testing.T) {
 			if err := a.Init(); (err != nil) != tt.wantErr {
 				t.Errorf("AppInit.Init() error = %v, wantErr %v", err, tt.wantErr)
 			}
-
-			require.DirExists(t, filepath.Join(tt.fields.Path, tt.fields.AppName))
-			for _, f := range tt.wantFiles {
-				require.FileExists(t, filepath.Join(tt.fields.Path, tt.fields.AppName, f))
-			}
-			require.FileExists(t, filepath.Join(tt.fields.Path, tt.fields.AppName, "fixtures", tt.wantFixtureFile))
+			assertDirectory(t, tt.fields.Path, tt.wantFiles)
 		})
+	}
+}
+
+// assertDirectory will continue checking for files and subdirectories until there's none left.
+func assertDirectory(t *testing.T, basePath string, dir directory) {
+	require.DirExists(t, filepath.Join(basePath, dir.name))
+
+	for _, file := range dir.files {
+		require.FileExists(t, filepath.Join(basePath, dir.name, file))
+	}
+
+	for _, subDir := range dir.subDirs {
+		assertDirectory(t, filepath.Join(basePath, dir.name), subDir)
 	}
 }


### PR DESCRIPTION
## Description of change

This is an improvement over what we had which will be needed to recursively clone a template with different subdirectories (will be needed for Java)

## Type of change

<!-- Please tick off the correct checkbox after saving the PR description. -->

- [x]  New feature
- [ ]  Bug fix
- [ ]  Refactor
- [ ]  Documentation

## How was this tested?

- [x]  Unit Tests
- [ ]  Tested in staging
- [ ]  Tested in minikube